### PR TITLE
Add fuzzy search to allow for typos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4681,6 +4681,11 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "fuzzysort": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-1.1.4.tgz",
+      "integrity": "sha512-JzK/lHjVZ6joAg3OnCjylwYXYVjRiwTY6Yb25LvfpJHK8bjisfnZJ5bY8aVWwTwCXgxPNgLAtmHL+Hs5q1ddLQ=="
+    },
     "generic-names": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generic-names/-/generic-names-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@popperjs/core": "^2.4.0",
     "focus-trap": "^5.1.0",
+    "fuzzysort": "^1.1.4",
     "tiny-emitter": "^2.1.0",
     "tslib": "^2.0.0",
     "twemoji": "^13.0.0"

--- a/src/search.ts
+++ b/src/search.ts
@@ -21,6 +21,8 @@ import {
   CLASS_EMOJI
 } from './classes';
 
+import fuzzysort from 'fuzzysort';
+
 class NotFoundMessage {
   constructor(private message: string, private iconUrl?: string) {}
 
@@ -210,12 +212,14 @@ export class Search {
         this.searchIcon.innerHTML = icons.times;
       }
       this.searchIcon.style.cursor = 'pointer';
-      const searchResults = this.emojiData.filter(
-        emoji =>
-          emoji.name
-            .toLowerCase()
-            .indexOf(this.searchField.value.toLowerCase()) >= 0
-      );
+
+      const searchResults = fuzzysort
+        .go(this.searchField.value, this.emojiData, {
+          allowTypo: true,
+          limit: 100,
+          key: 'name'
+        })
+        .map(result => result.obj); 
 
       this.events.emit(HIDE_PREVIEW);
 


### PR DESCRIPTION
Hi Joe, as we discussed on Twitter, I had some ideas for this library and wanted to kick things off with this little PR. It uses [fuzzysort](https://github.com/farzher/fuzzysort) to enable fuzzy search for emojis.

This results in an improved search experience, as it's very easy to make typos, resulting in the emoji picker returning no results in some cases.

![image](https://user-images.githubusercontent.com/10274434/88052228-d8e69100-cb51-11ea-90b0-6c674f5a52da.png)

With the fuzzy search enabled, the search is significantly improved, allowing for minor typos. The performance is still very good but takes a minor hit (~0.25ms [without fuzzy] vs ~0.38ms [with fuzzy]). 

Please take a look and let me know if this can be improved! :) 