### PR TITLE
Add missing rootElement option to types.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,6 +38,7 @@ declare namespace EmojiButton {
     custom?: CustomEmoji[];
     plugins?: Plugin[];
     icons?: Icons;
+    rootElement: HTMLElement;
   }
 
   export interface FixedPosition {


### PR DESCRIPTION
The lists a `rootElement` option, and that seems to exist in the types.ts file, but it is not listed in `index.d.ts`

This causes errors when trying to pass the `rootElement` option to the `EmojiButton`-costructor, even though there seems to be code that looks for that option in the constructor. The error messages look like this:

```
      TS2345: Argument of type '{ rootElement: any; }' is not assignable to parameter of type 'Options'.
  Object literal may only specify known properties, and 'rootElement' does not exist in type 'Options'.
```

This patch adds that missing `rootElement` option to the type definition.