### PR TITLE
Make rootElement optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,7 +38,7 @@ declare namespace EmojiButton {
     custom?: CustomEmoji[];
     plugins?: Plugin[];
     icons?: Icons;
-    rootElement: HTMLElement;
+    rootElement?: HTMLElement;
   }
 
   export interface FixedPosition {


### PR DESCRIPTION
The following example from the docs:
```javascript
const picker = new EmojiButton({
  position: 'bottom-start'
});
```
fails with the following error:
```
TS2345: Argument of type '{ position: "bottom-start"; }' is not assignable to parameter of type 'Options'.   Property 'rootElement' is missing in type '{ position: "bottom-start"; }' but required in type 'Options'.
```