### PR TITLE
Add "hidden" event

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -68,7 +68,7 @@ declare namespace EmojiButton {
 
   export type EmojiTheme = 'dark' | 'light' | 'auto';
 
-  export type Event = 'emoji';
+  export type Event = 'emoji' | 'hidden';
 
   export type Placement =
     | 'auto'

--- a/site/src/components/Sidebar.js
+++ b/site/src/components/Sidebar.js
@@ -22,6 +22,11 @@ export default function Sidebar() {
           </Link>
         </li>
         <li>
+          <Link activeClassName={styles.active} to="/docs/events">
+            Events
+          </Link>
+        </li>
+        <li>
           <Link activeClassName={styles.active} to="/docs/styles">
             Styles
           </Link>

--- a/site/src/examples/events/emoji.js
+++ b/site/src/examples/events/emoji.js
@@ -1,0 +1,5 @@
+const picker = new EmojiButton();
+
+picker.on('emoji', selection => {
+  alert(`"emoji" event fired, emoji is ${selection.emoji}`);
+});

--- a/site/src/examples/events/hidden.js
+++ b/site/src/examples/events/hidden.js
@@ -1,0 +1,5 @@
+const picker = new EmojiButton();
+
+picker.on('hidden', () => {
+  alert('"hidden" event fired');
+});

--- a/site/src/pages/docs/api.js
+++ b/site/src/pages/docs/api.js
@@ -479,15 +479,15 @@ export default function ApiDocs() {
         </h3>
         <p>
           Removes the given listener for the given event. See{' '}
-          <a href="#events">Events</a> for a list of valid events.
+          <Link to="/docs/events">Events</Link> for a list of valid events.
         </p>
 
         <h3>
           Method: <code>on(event, callback)</code>
         </h3>
         <p>
-          Adds a listener for the given event. See <a href="#events">Events</a>{' '}
-          for a list of valid events.
+          Adds a listener for the given event. See{' '}
+          <Link to="/docs/events">Events</Link> for a list of valid events.
         </p>
 
         <h3>
@@ -506,32 +506,6 @@ export default function ApiDocs() {
           <code>referenceElement</code>) if it is hidden, and hides it if it is
           visible.
         </p>
-
-        <a name="events" />
-        <h2>Events</h2>
-
-        <h3>
-          <code>emoji</code>
-        </h3>
-        <p>
-          Fired when an emoji is selected. The callback will receive a single
-          object with one or more of the following properties:
-        </p>
-        <ul>
-          <li>
-            <code>custom</code>: This will be <code>true</code> for a custom
-            emoji.
-          </li>
-          <li>
-            <code>emoji</code>: The Unicode emoji character that was selected.
-            This will be included for native and Twemoji emojis, but not for
-            custom emojis.
-          </li>
-          <li>
-            <code>url</code>: The URL of the emoji image. This will be included
-            for Twemoji and custom emojis.
-          </li>
-        </ul>
 
         <a name="categories" />
         <h2>Category IDs</h2>

--- a/site/src/pages/docs/events.js
+++ b/site/src/pages/docs/events.js
@@ -1,0 +1,108 @@
+import React, { useRef, useState, useEffect } from 'react';
+
+import { EmojiButton } from '@joeattardi/emoji-button';
+
+import styles from '../../components/Example.module.css';
+
+import DocLayout from '../../components/DocLayout';
+import SourceFile from '../../components/SourceFile';
+
+import emojiExample from '!!raw-loader!../../examples/events/emoji.js';
+import hiddenExample from '!!raw-loader!../../examples/events/hidden.js';
+
+function EventExample({
+  initialEmoji = '😎',
+  initialImageUrl,
+  options,
+  event,
+  eventCallback
+}) {
+  const buttonRef = useRef();
+  const [picker, setPicker] = useState(null);
+  const [emoji, setEmoji] = useState(initialEmoji);
+  const [imageUrl, setImageUrl] = useState(initialImageUrl);
+
+  useEffect(() => {
+    const pickerObj = new EmojiButton(options);
+
+    pickerObj.on('emoji', selection => {
+      setEmoji(selection.emoji);
+      setImageUrl(selection.url);
+    });
+
+    pickerObj.on(event,eventCallback);
+
+    setPicker(pickerObj);
+  }, []);
+
+  function togglePicker() {
+    picker.togglePicker(buttonRef.current);
+  }
+
+  return (
+    <button
+      className={styles.emojiButton}
+      ref={buttonRef}
+      onClick={togglePicker}
+    >
+      {imageUrl ? <img alt={emoji} src={imageUrl} /> : <span>{emoji}</span>}
+    </button>
+  );
+}
+
+function onEmoji(selection)
+{
+  alert(`"emoji" event fired, emoji is ${selection.emoji}`);
+}
+
+function onHidden()
+{
+  alert('"hidden" event fired');
+}
+
+export default function Events() {
+  return (
+    <DocLayout>
+      <h1>Events</h1>
+      
+      <p>
+        The <code>EmojiButton</code> class emits the following events:
+      </p>
+      
+      <h2>
+        <code>emoji</code>
+      </h2>
+      <p>
+        Fired when an emoji is selected. The callback will receive a single
+        object with one or more of the following properties:
+      </p>
+      <ul>
+        <li>
+          <code>custom</code>: This will be <code>true</code> for a custom
+          emoji.
+        </li>
+        <li>
+          <code>emoji</code>: The Unicode emoji character that was selected.
+          This will be included for native and Twemoji emojis, but not for
+          custom emojis.
+        </li>
+        <li>
+          <code>url</code>: The URL of the emoji image. This will be included
+          for Twemoji and custom emojis.
+        </li>
+      </ul>
+      <EventExample event="emoji" eventCallback={onEmoji}/>
+      <SourceFile src={emojiExample} />
+
+      <h2>
+        <code>hidden</code>
+      </h2>
+      <p>
+        Fired when the picker is hidden.
+      </p>
+      <EventExample event="hidden" eventCallback={onHidden}/>
+      <SourceFile src={hiddenExample} />
+
+    </DocLayout>
+  );
+}

--- a/src/events.ts
+++ b/src/events.ts
@@ -5,3 +5,4 @@ export const SHOW_PREVIEW = 'showPreview';
 export const HIDE_PREVIEW = 'hidePreview';
 export const HIDE_VARIANT_POPUP = 'hideVariantPopup';
 export const CATEGORY_CLICKED = 'categoryClicked';
+export const PICKER_HIDDEN = 'hidden';

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,8 @@ import {
   EMOJI,
   SHOW_SEARCH_RESULTS,
   HIDE_SEARCH_RESULTS,
-  HIDE_VARIANT_POPUP
+  HIDE_VARIANT_POPUP,
+  PICKER_HIDDEN
 } from './events';
 import { EmojiPreview } from './preview';
 import { Search } from './search';
@@ -408,6 +409,8 @@ export class EmojiButton {
       }
 
       this.hideInProgress = false;
+
+      this.publicEvents.emit(PICKER_HIDDEN);
     }, 170);
 
     setTimeout(() => {


### PR DESCRIPTION
This PR adds a "hidden" event which is emitted when the picker is closed.

Since there are now 2 public events, I also took the liberty to add a dedicated "events" page with examples to the documentation, replacing the section on the API page.

I tried to keep the documentation as consistent as I could, but I have no experience with either gatsby or react, so I'm happy to make any changes if things can be done in a better way. :)