### PR TITLE
Fix error when hiding picker after showing in mobile mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,7 @@ export class EmojiButton {
 
   private emojiArea: EmojiArea;
 
-  private overlay: HTMLElement;
+  private overlay?: HTMLElement;
 
   private popper: Popper;
 
@@ -381,6 +381,7 @@ export class EmojiButton {
 
     if (this.overlay) {
       document.body.removeChild(this.overlay);
+      this.overlay = undefined;
     }
 
     this.pickerEl.classList.add('hiding');


### PR DESCRIPTION
This fixes a DOMException due to the mobile overlay being double-removed from the DOM in the following situation:

1. resize the browser viewport to <= 450px to trigger the mobile mode
2. show the picker, which creates the mobile overlay
3. hide the picker, which removes the overlay from the DOM
4. resize the browser viewport to > 450px
5. show the picker
6. hide the picker, which attempts to remove the overlay from the DOM again