### PR TITLE
Custom themes

### DIFF
--- a/css/emoji-button.css
+++ b/css/emoji-button.css
@@ -80,7 +80,10 @@
   --focus-indicator-color: #999999;
 
   --search-height: 2em;
+}
 
+.emoji-picker__wrapper
+{
   --blue-color: #4F81E5;
 
   --border-color: #CCCCCC;
@@ -116,7 +119,7 @@
   --dark-category-button-active-color: var(--blue-color);
 }
 
-.emoji-picker.dark
+.emoji-picker__wrapper.dark
 {
   --border-color: var(--dark-border-color);
   --background-color: var(--dark-background-color);
@@ -138,7 +141,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  .emoji-picker.auto {
+  .emoji-picker__wrapper.auto {
     --border-color: var(--dark-border-color);
     --background-color: var(--dark-background-color);
     --text-color: var(--dark-text-color);

--- a/css/emoji-button.css
+++ b/css/emoji-button.css
@@ -88,6 +88,10 @@
   --text-color: #000000;
   --secondary-text-color: #666666;
   --hover-color: #E8F4F9;
+  --search-background-color: var(--background-color);
+  --search-border-color: var(--border-color);
+  --search-text-color: var(--text-color);
+  --search-placeholder-color: #767676;
   --search-focus-border-color: var(--blue-color);
   --search-icon-color: #CCCCCC;
   --overlay-background-color: rgba(0, 0, 0, 0.8);
@@ -102,10 +106,57 @@
   --dark-hover-color: #666666;
   --dark-search-background-color: #666666;
   --dark-search-border-color: #999999;
+  --dark-search-text-color: var(--dark-text-color);
   --dark-search-placeholder-color: #999999;
   --dark-search-focus-border-color: #DBE5F9;
+  --dark-search-icon-color: #CCCCCC;
+  --dark-overlay-background-color: rgba(0, 0, 0, 0.8);
   --dark-popup-background-color: #333333;
   --dark-category-button-color: #FFFFFF;
+  --dark-category-button-active-color: var(--blue-color);
+}
+
+.emoji-picker.dark
+{
+  --border-color: var(--dark-border-color);
+  --background-color: var(--dark-background-color);
+  --text-color: var(--dark-text-color);
+  --secondary-text-color: var(--dark-secondary-text-color);
+  --hover-color: var(--dark-hover-color);
+
+  --search-background-color: var(--dark-search-background-color);
+  --search-border-color: var(--dark-search-border-color);
+  --search-text-color: var(--dark-search-text-color);
+  --search-placeholder-color: var(--dark-search-placeholder-color);
+  --search-focus-border-color: var(--dark-search-focus-border-color);
+  --search-icon-color: var(--dark-search-icon-color);
+
+  --overlay-background-color: var(--dark-overlay-background-color);
+  --popup-background-color: var(--dark-popup-background-color);
+  --category-button-color: var(--dark-category-button-color);
+  --category-button-active-color: var(--dark-category-button-active-color);
+}
+
+@media (prefers-color-scheme: dark) {
+  .emoji-picker.auto {
+    --border-color: var(--dark-border-color);
+    --background-color: var(--dark-background-color);
+    --text-color: var(--dark-text-color);
+    --secondary-text-color: var(--dark-secondary-text-color);
+    --hover-color: var(--dark-hover-color);
+  
+    --search-background-color: var(--dark-search-background-color);
+    --search-border-color: var(--dark-search-border-color);
+    --search-text-color: var(--dark-search-text-color);
+    --search-placeholder-color: var(--dark-search-placeholder-color);
+    --search-focus-border-color: var(--dark-search-focus-border-color);
+    --search-icon-color: var(--dark-search-icon-color);
+  
+    --overlay-background-color: var(--dark-overlay-background-color);
+    --popup-background-color: var(--dark-popup-background-color);
+    --category-button-color: var(--dark-category-button-color);
+    --category-button-active-color: var(--dark-category-button-active-color);
+  }
 }
 
 .emoji-picker {
@@ -138,12 +189,6 @@
   animation: hide var(--animation-duration) var(--animation-easing);
 }
 
-.emoji-picker.dark {
-  background: var(--dark-background-color);
-  color: var(--dark-text-color);
-  border-color: var(--dark-border-color);
-}
-
 .emoji-picker__content {
   padding: 0.5em;
   height: var(--content-height);
@@ -157,10 +202,6 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-}
-
-.emoji-picker.dark .emoji-picker__preview {
-  border-top-color: var(--dark-border-color);
 }
 
 .emoji-picker__preview-emoji {
@@ -181,10 +222,6 @@
   font-size: 0.85em;
   overflow-wrap: break-word;
   word-break: break-all;
-}
-
-.emoji-picker.dark .emoji-picker__preview-name {
-  color: var(--dark-text-color);
 }
 
 .emoji-picker__container {
@@ -236,10 +273,6 @@
   outline: 1px dotted var(--focus-indicator-color);
 }
 
-.emoji-picker.dark .emoji-picker__emoji:focus, .emoji-picker.dark .emoji-picker__emoji:hover {
-  background: var(--dark-hover-color);
-}
-
 .emoji-picker__plugin-container {
   margin: 0.5em;
   display: flex;
@@ -257,29 +290,22 @@
   box-sizing: border-box;
   width: 100%;
   border-radius: 3px;
-  border: 1px solid var(--border-color);
+  background: var(--search-background-color);
+  color: var(--search-text-color);
+  border: 1px solid var(--search-border-color);
   padding-right: 2em;
   padding: 0.5em 2.25em 0.5em 0.5em;
   font-size: 0.85em;
   outline: none;
 }
 
-.emoji-picker.dark .emoji-picker__search {
-  background: var(--dark-search-background-color);
-  color: var(--dark-text-color);
-  border-color: var(--dark-search-border-color);
-}
-
-.emoji-picker.dark .emoji-picker__search::placeholder {
-  color: var(--dark-search-placeholder-color);
+.emoji-picker__search::placeholder {
+  color: var(--search-placeholder-color);
+  opacity: 1;
 }
 
 .emoji-picker__search:focus {
   border: 1px solid var(--search-focus-border-color);
-}
-
-.emoji-picker.dark .emoji-picker__search:focus {
-  border-color: var(--dark-search-focus-border-color);
 }
 
 .emoji-picker__search-icon {
@@ -307,14 +333,6 @@
 
 .emoji-picker__search-not-found h2 {
   color: var(--secondary-text-color);
-}
-
-.emoji-picker.dark .emoji-picker__search-not-found {
-  color: var(--dark-secondary-text-color);
-}
-
-.emoji-picker.dark .emoji-picker__search-not-found h2 {
-  color: var(--dark-secondary-text-color);
 }
 
 .emoji-picker__search-not-found-icon {
@@ -363,10 +381,6 @@
   animation: shrink var(--animation-duration) var(--animation-easing);
 }
 
-.emoji-picker.dark .emoji-picker__variant-popup {
-  background: var(--dark-popup-background-color);
-}
-
 .emoji-picker__emojis {
   overflow-y: auto;
   position: relative;
@@ -383,10 +397,6 @@
   text-transform: uppercase;
   margin: 0.25em 0;
   text-align: left;
-}
-
-.emoji-picker.dark h2.emoji-picker__category-name {
-  color: var(--dark-secondary-text-color);
 }
 
 .emoji-picker__category-buttons {
@@ -419,73 +429,7 @@ button.emoji-picker__category-button img {
   outline: 1px dotted var(--focus-indicator-color);
 }
 
-.emoji-picker.dark button.emoji-picker__category-button.active {
-  color: var(--category-button-active-color);
-}
-
-.emoji-picker.dark button.emoji-picker__category-button {
-  color: var(--dark-category-button-color);
-}
-
 button.emoji-picker__category-button.active {
   color: var(--category-button-active-color);
   border-bottom: var(--category-border-bottom-size) solid var(--category-button-active-color);
-}
-
-@media (prefers-color-scheme: dark) {
-  .emoji-picker.auto {
-    background: var(--dark-background-color);
-    color: var(--dark-text-color);
-    border-color: var(--dark-border-color);
-  }
-
-  .emoji-picker.auto .emoji-picker__preview {
-    border-top-color: var(--dark-border-color);
-  }
-
-  .emoji-picker.auto .emoji-picker__preview-name {
-    color: var(--dark-text-color);
-  }
-
-  .emoji-picker.auto button.emoji-picker__category-button {
-    color: var(--dark-category-button-color);
-  }
-
-  .emoji-picker.auto button.emoji-picker__category-button.active {
-    color: var(--category-button-active-color);
-  }
-
-  .emoji-picker.auto .emoji-picker__emoji:focus, .emoji-picker.auto .emoji-picker__emoji:hover {
-    background: var(--dark-hover-color);
-  }
-
-  .emoji-picker.auto .emoji-picker__search {
-    background: var(--dark-search-background-color);
-    color: var(--dark-text-color);
-    border-color: var(--dark-search-border-color);
-  }
- 
-  .emoji-picker.auto h2.emoji-picker__category-name {
-    color: var(--dark-secondary-text-color);
-  }
-
-  .emoji-picker.auto .emoji-picker__search::placeholder {
-    color: var(--dark-search-placeholder-color);
-  }
-
-  .emoji-picker.auto .emoji-picker__search:focus {
-    border-color: var(--dark-search-focus-border-color);
-  }
-
-  .emoji-picker.auto .emoji-picker__search-not-found {
-    color: var(--dark-secondary-text-color);
-  }
-
-  .emoji-picker.auto .emoji-picker__search-not-found h2 {
-    color: var(--dark-secondary-text-color);
-  }
-
-  .emoji-picker.auto .emoji-picker__variant-popup {
-    background: var(--dark-popup-background-color);
-  }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -67,7 +67,14 @@ declare namespace EmojiButton {
 
   export type EmojiStyle = 'native' | 'twemoji';
 
-  export type EmojiTheme = 'dark' | 'light' | 'auto';
+  export type EmojiBaseTheme = 'dark' | 'light' | 'auto';
+
+  export interface EmojiCustomTheme {
+    extends?:EmojiBaseTheme;
+    className:string;
+  }
+
+  export type EmojiTheme = EmojiBaseTheme | EmojiCustomTheme;
 
   export type Event = 'emoji' | 'hidden';
 

--- a/site/src/examples/themes/custom.highcontrast.css
+++ b/site/src/examples/themes/custom.highcontrast.css
@@ -1,0 +1,19 @@
+.emoji-picker-high-contrast {
+  --border-color: #FFFFFF;
+  --background-color: #000000;
+  --text-color: #FFFFFF;
+  --secondary-text-color: #FFFFFF;
+  --hover-color: #00FFFF;
+
+  --search-background-color: #000000;
+  --search-border-color: #FFFFFF;
+  --search-text-color: #FFFFFF;
+  --search-placeholder-color: #FFFF00;
+  --search-focus-border-color: #00FFFF;
+  --search-icon-color: #FFFFFF;
+
+  --overlay-background-color: rgba(0,0,0,0.9);
+  --popup-background-color: #000000;
+  --category-button-color: #FFFFFF;
+  --category-button-active-color: #00FFFF;
+}

--- a/site/src/examples/themes/custom.minimal.css
+++ b/site/src/examples/themes/custom.minimal.css
@@ -1,0 +1,5 @@
+.emoji-picker-minimal {
+  --background-color: #323F49;
+  --search-focus-border-color: #FF6E00;
+  --category-button-active-color: #FF6E00;
+}

--- a/site/src/examples/themes/highcontrast.js
+++ b/site/src/examples/themes/highcontrast.js
@@ -1,0 +1,3 @@
+const picker = new EmojiButton({
+  theme: {className:'emoji-picker-high-contrast'}
+});

--- a/site/src/examples/themes/minimal.js
+++ b/site/src/examples/themes/minimal.js
@@ -1,0 +1,3 @@
+const picker = new EmojiButton({
+  theme: {extends:'dark', className:'emoji-picker-minimal'}
+});

--- a/site/src/examples/themes/switch-theme.js
+++ b/site/src/examples/themes/switch-theme.js
@@ -5,3 +5,4 @@ const picker = new EmojiButton();
 document.querySelector('#set-theme-dark').addEventListener('click', () => picker.setTheme("dark"));
 document.querySelector('#set-theme-light').addEventListener('click', () => picker.setTheme("light"));
 document.querySelector('#set-theme-auto').addEventListener('click', () => picker.setTheme("auto"));
+document.querySelector('#set-theme-custom').addEventListener('click', () => picker.setTheme({className:'emoji-picker-high-contrast'}));

--- a/site/src/pages/docs/api.js
+++ b/site/src/pages/docs/api.js
@@ -436,6 +436,9 @@ export default function ApiDocs() {
                   <li>
                     <code>'auto'</code>: Use the operating system setting.
                   </li>
+                  <li>
+                    A <Link to="/docs/themes#custom">Custom Theme</Link> object
+                  </li>
                 </ul>
               </td>
             </tr>

--- a/site/src/pages/docs/themes.js
+++ b/site/src/pages/docs/themes.js
@@ -13,6 +13,14 @@ import switchExample from '!!raw-loader!../../examples/themes/switch-theme.js';
 
 import styles from './plugins.module.css';
 
+import highContrastTheme from '!!raw-loader!../../examples/themes/custom.highcontrast.css';
+import '../../examples/themes/custom.highcontrast.css';
+import highContrastThemeExample from '!!raw-loader!../../examples/themes/highcontrast.js';
+
+import minimalTheme from '!!raw-loader!../../examples/themes/custom.minimal.css';
+import '../../examples/themes/custom.minimal.css';
+import minimalThemeExample from '!!raw-loader!../../examples/themes/minimal.js';
+
 export default function ThemesExample() {
   
   const buttonRef = useRef();
@@ -39,6 +47,10 @@ export default function ThemesExample() {
 
   function setAuto() {
     picker.setTheme("auto");
+  }
+
+  function setCustom() {
+    picker.setTheme({className:'emoji-picker-high-contrast'});
   }
 
   return (
@@ -111,9 +123,53 @@ export default function ThemesExample() {
         >
           auto
         </button>
+
+        <button
+          id="set-theme-custom"
+          onClick={setCustom}
+        >
+          custom
+        </button>
       </div>
 
       <SourceFile src={switchExample} />
+
+      <a name="custom" />
+      <h1>Custom Themes</h1>
+      <p>
+        You can use custom themes by passing an object with a <code>className</code>{' '}
+        property specifying the CSS class which contains the custom theme properties, 
+        and an optional <code>extends</code> property, specifying the base theme 
+        (<code>light</code>, <code>dark</code>, or <code>auto</code>) to extend from.
+      </p>
+
+      <h2>Example - High Contrast</h2>
+      <p>
+        This theme changes every available variable, customizing the entire component.
+      </p>
+      <Example options={{ theme: {className:'emoji-picker-high-contrast'} }} />
+      <SourceFile src={highContrastThemeExample} />
+      <pre>
+        <code
+          className="language-css"
+          dangerouslySetInnerHTML={{ __html:highContrastTheme}}
+        />
+      </pre>
+
+      <h2>Example - Minimal</h2>
+      <p>
+        If the dark theme generally works for your application, but you'd like to customize a few colors to 
+        better match your brand, that's easily done:
+      </p>
+      <Example options={{ theme: {extends:'dark', className:'emoji-picker-minimal'} }} />
+      <SourceFile src={minimalThemeExample} />
+      <pre>
+        <code
+          className="language-css"
+          dangerouslySetInnerHTML={{ __html:minimalTheme}}
+        />
+      </pre>
+
     </DocLayout>
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,7 +135,7 @@ export class EmojiButton {
     this.onDocumentClick = this.onDocumentClick.bind(this);
     this.onDocumentKeydown = this.onDocumentKeydown.bind(this);
 
-    this.theme = resolveTheme(this.options.theme || 'light');
+    this.theme = resolveTheme(this.options.theme || DEFAULT_THEME);
 
     this.buildPicker();
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ import {
   EmojiTheme,
   EmojiThemeInternal,
   EmojiCustomThemeInternal,
-  EmojiBaseTheme, EmojiCustomTheme
+  EmojiBaseTheme
 } from './types';
 import { EmojiArea } from './emojiArea';
 import { compareThemes } from './themes';

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -1,0 +1,14 @@
+import { EmojiCustomTheme, EmojiTheme } from "./types";
+
+const compareCustomThemes = (a:EmojiCustomTheme,b:EmojiCustomTheme): boolean => {
+	return a.extends == b.extends && a.className == b.className;
+  }
+
+export const compareThemes = (a:EmojiTheme, b:EmojiTheme): boolean => {
+	if (typeof a !== typeof b) return false;
+	if (typeof a !== "string") {
+	  return compareCustomThemes(a,<EmojiCustomTheme>b); //both themes are custom, since we know they have the same type
+	} else {
+	  return a === b;
+	}
+  }

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,7 +70,17 @@ export interface FixedPosition {
 
 export type EmojiStyle = 'native' | 'twemoji';
 
-export type EmojiTheme = 'dark' | 'light' | 'auto';
+export type EmojiBaseTheme = 'dark' | 'light' | 'auto';
+
+export interface EmojiCustomTheme {
+  extends?:EmojiBaseTheme;
+  className:string;
+}
+export type EmojiTheme = EmojiBaseTheme | EmojiCustomTheme;
+
+export type EmojiCustomThemeInternal = Required<EmojiCustomTheme>;
+
+export type EmojiThemeInternal = EmojiBaseTheme | EmojiCustomThemeInternal;
 
 export type EmojiVersion =
   | '1.0'


### PR DESCRIPTION
There are 2 parts to this:
- a refactor of the internal css variables allowing for custom theme support (https://github.com/joeattardi/emoji-button/commit/2834f30289db904f4ddceedb6219cae732e2e14e)
- the custom theme support itself, which is a thin wrapper that adds classes to the proper elements

One thing of note is that base themes are applied to the wrapper, while custom themes are applied to the picker.  This allows custom themes to extend base themes, while still overriding variables since they have the same specificity.

The one thing I didn't add to the documentation is a description of the available CSS variables for theming, but I think the names are self explanatory, and I provided an example which overrides every variable, which serves as a kind of reference.

Of course, let me know if you think anything should be added or changed.  Thanks!