### PR TITLE
Added ability to exclude emojis

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,6 +40,7 @@ declare namespace EmojiButton {
     plugins?: Plugin[];
     icons?: Icons;
     rootElement?: HTMLElement;
+    excludeEmojis?: string[] | ((emoji:string) => boolean);
   }
 
   export interface FixedPosition {

--- a/site/src/examples/customize/excludeEmojis.js
+++ b/site/src/examples/customize/excludeEmojis.js
@@ -1,0 +1,3 @@
+const picker = new EmojiButton({
+  excludeEmojis:['🍏','🍎']
+});

--- a/site/src/pages/docs/api.js
+++ b/site/src/pages/docs/api.js
@@ -450,6 +450,27 @@ export default function ApiDocs() {
                 If specified, sets the Z-index for the emoji picker element.
               </td>
             </tr>
+
+            <tr>
+              <th scope="row">
+                <code>excludeEmojis</code>
+              </th>
+              <td>string array or function</td>
+              <td>none</td>
+              <td>
+                Excludes emoji from the picker.  This can be either:
+                <ul>
+                  <li>
+                    an array of emojis to exclude
+                  </li>
+                  <li>
+                    a function which takes an emoji and returns{' '}
+                    <code>true</code> to exclude the emoji, or{' '}
+                    <code>false</code> to include it.
+                  </li>
+                </ul>
+              </td>
+            </tr>
           </tbody>
         </table>
 

--- a/site/src/pages/docs/customize.js
+++ b/site/src/pages/docs/customize.js
@@ -10,6 +10,7 @@ import sizeExample from '!!raw-loader!../../examples/customize/size.js';
 import emojiVersionExample from '!!raw-loader!../../examples/customize/emojiVersion.js';
 import initialCategoryExample from '!!raw-loader!../../examples/customize/initialCategory.js';
 import hideElementsExample from '!!raw-loader!../../examples/customize/hideElements.js';
+import excludeEmojisExample from '!!raw-loader!../../examples/customize/excludeEmojis.js';
 
 export default function CustomizationExample() {
   return (
@@ -86,6 +87,13 @@ export default function CustomizationExample() {
         }}
       />
       <SourceFile src={hideElementsExample} />
+
+      <h2>Excluding Emojis</h2>
+      <p>
+        Undesired emojis can be excluded from the picker.
+      </p>
+      <Example options={{excludeEmojis:['🍏','🍎']}} />
+      <SourceFile src={excludeEmojisExample} />
     </DocLayout>
   );
 }

--- a/src/emojiContainer.test.ts
+++ b/src/emojiContainer.test.ts
@@ -2,6 +2,16 @@ import { TinyEmitter as Emitter } from 'tiny-emitter';
 
 import { EmojiContainer } from './emojiContainer';
 
+const exclusionTestEmojis = [
+  { emoji: '⚡️', version: '12.1', name: 'zap', category: 0 },
+  { emoji: '💩', version: '1.0', name: 'pile of poo', category: 0 },
+  { emoji: '👍', version: '12.1', name: 'thumbs up', category: 0 },
+  { emoji: '🐩', version: '1.0', name: 'poddle', category: 2 },
+  { emoji: '🍎', version: '1.0', name: 'red apple', category: 3 },
+  { emoji: '🍏', version: '1.0', name: 'green apple', category: 3 },
+  { emoji: '🍕', version: '1.0', name: 'pizza', category: 3 }
+];
+
 describe('EmojiContainer', () => {
   test('should render all the given emojis', () => {
     const emojis = [
@@ -15,5 +25,36 @@ describe('EmojiContainer', () => {
       emojiVersion: '12.1'
     }).render();
     expect(container.querySelectorAll('.emoji-picker__emoji').length).toBe(2);
+  });
+
+  test('should exclude specified emojis via function', () => {
+    const events = new Emitter();
+
+    const container = new EmojiContainer(exclusionTestEmojis, false, events, {
+      emojiVersion: '12.1',
+      excludeEmojis: e => e == '💩' || e == '🐩' || e == '🍕'
+    }).render();
+    expect(container.querySelectorAll('.emoji-picker__emoji').length).toBe(4);
+  });
+
+  test('should exclude specified emojis via array', () => {
+    const events = new Emitter();
+
+    const container = new EmojiContainer(exclusionTestEmojis, false, events, {
+      emojiVersion: '12.1',
+      excludeEmojis: ['🍏', '🍎']
+    }).render();
+    expect(container.querySelectorAll('.emoji-picker__emoji').length).toBe(5);
+  });
+
+  test('should not exclude any emojis when excludeEmoji is not specified', () => {
+    const events = new Emitter();
+
+    const container = new EmojiContainer(exclusionTestEmojis, false, events, {
+      emojiVersion: '12.1'
+    }).render();
+    expect(container.querySelectorAll('.emoji-picker__emoji').length).toBe(
+      exclusionTestEmojis.length
+    );
   });
 });

--- a/src/emojiContainer.ts
+++ b/src/emojiContainer.ts
@@ -7,6 +7,8 @@ import { CLASS_EMOJI_CONTAINER } from './classes';
 
 import { EmojiButtonOptions, EmojiRecord, RecentEmoji } from './types';
 
+import { createExcluder } from './excluder';
+
 export class EmojiContainer {
   private emojis: Array<EmojiRecord | RecentEmoji>;
 
@@ -17,20 +19,14 @@ export class EmojiContainer {
     private options: EmojiButtonOptions,
     private lazy = true
   ) {
-    const exclude = options.excludeEmojis;
+    const isExcluded = createExcluder(options.excludeEmojis);
     this.emojis = emojis.filter(e => {
       const verCheck =
         !(e as EmojiRecord).version ||
         parseFloat((e as EmojiRecord).version as string) <=
           parseFloat(options.emojiVersion as string);
 
-      const isExcluded =
-        exclude !== undefined &&
-        (typeof exclude === 'function'
-          ? exclude(e.emoji)
-          : exclude.includes(e.emoji));
-
-      return verCheck && !isExcluded;
+      return verCheck && !isExcluded(e);
     });
   }
 

--- a/src/emojiContainer.ts
+++ b/src/emojiContainer.ts
@@ -17,12 +17,21 @@ export class EmojiContainer {
     private options: EmojiButtonOptions,
     private lazy = true
   ) {
-    this.emojis = emojis.filter(
-      e =>
+    const exclude = options.excludeEmojis;
+    this.emojis = emojis.filter(e => {
+      const verCheck =
         !(e as EmojiRecord).version ||
         parseFloat((e as EmojiRecord).version as string) <=
-          parseFloat(options.emojiVersion as string)
-    );
+          parseFloat(options.emojiVersion as string);
+
+      const isExcluded =
+        exclude !== undefined &&
+        (typeof exclude === 'function'
+          ? exclude(e.emoji)
+          : exclude.includes(e.emoji));
+
+      return verCheck && !isExcluded;
+    });
   }
 
   render(): HTMLElement {

--- a/src/excluder.ts
+++ b/src/excluder.ts
@@ -1,0 +1,12 @@
+import { EmojiRecord, ExcludeEmojis } from './types';
+
+/** returns a function that checks if emojis should be excluded */
+export const createExcluder = (
+  exclude?: ExcludeEmojis
+): ((e: EmojiRecord) => boolean) => {
+  if (exclude === undefined) return () => false;
+
+  return typeof exclude === 'function'
+    ? (e: EmojiRecord) => exclude(e.emoji)
+    : (e: EmojiRecord) => exclude.includes(e.emoji);
+};

--- a/src/search.test.ts
+++ b/src/search.test.ts
@@ -6,13 +6,14 @@ import { Search } from './search';
 import { i18n } from './i18n';
 import { EmojiButtonOptions, EmojiRecord } from './types';
 
-describe('Search', () => {
-  const emojis: EmojiRecord[] = [
-    { category: 0, emoji: '⚡️', name: 'zap', version: '12.1' },
-    { category: 1, emoji: '😀', name: 'grinning', version: '12.1' }
-  ];
+const emojis: EmojiRecord[] = [
+  { category: 0, emoji: '⚡️', name: 'zap', version: '12.1' },
+  { category: 1, emoji: '😀', name: 'grinning', version: '12.1' }
+];
 
-  const options: EmojiButtonOptions = { emojiVersion: '12.1', style: 'native' };
+const options: EmojiButtonOptions = { emojiVersion: '12.1', style: 'native' };
+
+describe('Search', () => {
   let events;
   let search;
   let searchField;
@@ -62,6 +63,32 @@ describe('Search', () => {
     });
 
     searchField.value = 'blah';
+    searchField.dispatchEvent(new KeyboardEvent('keyup'));
+  });
+});
+
+describe('Search with Exclusions', () => {
+  test('should not show results for excluded emojis', done => {
+    const events = new Emitter();
+    const search = new Search(
+      events,
+      i18n,
+      { ...options, excludeEmojis: ['⚡️'] },
+      emojis,
+      [0]
+    ).render();
+    events.on(SHOW_SEARCH_RESULTS, searchResultsContainer => {
+      const searchResults = searchResultsContainer.querySelectorAll(
+        '.emoji-picker__emoji'
+      );
+      expect(searchResults.length).toBe(0);
+      done();
+    });
+
+    const searchField = <HTMLInputElement>(
+      search.querySelector('.emoji-picker__search')
+    );
+    searchField.value = 'zap';
     searchField.dispatchEvent(new KeyboardEvent('keyup'));
   });
 });

--- a/src/search.ts
+++ b/src/search.ts
@@ -22,6 +22,7 @@ import {
 } from './classes';
 
 import fuzzysort from 'fuzzysort';
+import { createExcluder } from './excluder';
 
 class NotFoundMessage {
   constructor(private message: string, private iconUrl?: string) {}
@@ -65,12 +66,14 @@ export class Search {
     categories: number[]
   ) {
     this.emojisPerRow = this.options.emojisPerRow || 8;
+    const isExcluded = createExcluder(this.options.excludeEmojis);
     this.emojiData = emojiData.filter(
       e =>
         e.version &&
         parseFloat(e.version) <= parseFloat(options.emojiVersion as string) &&
         e.category !== undefined &&
-        categories.indexOf(e.category) >= 0
+        categories.indexOf(e.category) >= 0 &&
+        !isExcluded(e)
     );
 
     if (this.options.custom) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,7 @@ export interface EmojiButtonOptions {
   custom?: EmojiRecord[];
   plugins?: Plugin[];
   icons?: Icons;
+  excludeEmojis?: string[] | ((emoji: string) => boolean);
 }
 
 export interface FixedPosition {

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,8 @@ export interface Plugin {
   destroy?(): void;
 }
 
+export type ExcludeEmojis = string[] | ((emoji: string) => boolean);
+
 export interface EmojiButtonOptions {
   position?: Placement | FixedPosition;
   autoHide?: boolean;
@@ -59,7 +61,7 @@ export interface EmojiButtonOptions {
   custom?: EmojiRecord[];
   plugins?: Plugin[];
   icons?: Icons;
-  excludeEmojis?: string[] | ((emoji: string) => boolean);
+  excludeEmojis?: ExcludeEmojis;
 }
 
 export interface FixedPosition {


### PR DESCRIPTION
This adds the ability to exclude emojis by either specifying an array of the emojis to exclude, or a function which takes an emoji and returns either true to exclude it, or false to include it.

One thing I noticed while developing this is that the picker breaks when there are categories without any emojis in them.  I don't think it's a big deal, as the user would have to manually exclude all emojis in a category, but I just thought I would mention it. :)