### PR TITLE
Fix picker jumping before being destroyed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -388,7 +388,6 @@ export class EmojiButton {
     this.hideInProgress = true;
     this.focusTrap.deactivate();
     this.pickerVisible = false;
-    this.popper && this.popper.destroy();
 
     if (this.overlay) {
       document.body.removeChild(this.overlay);
@@ -428,6 +427,7 @@ export class EmojiButton {
         }
 
         this.hideInProgress = false;
+        this.popper && this.popper.destroy();
 
         this.publicEvents.emit(PICKER_HIDDEN);
       },


### PR DESCRIPTION
This is only visible when using a rootElement.  The popper was destroyed before the hide animation started, so the picker jumped to 0,0 for the duration of the animation.