### PR TITLE
Add 'module' key

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "javascript"
   ],
   "main": "dist/index.js",
+  "module": "dist/index.js",
   "types": "index.d.ts",
   "scripts": {
     "build": "cross-env NODE_ENV=production rollup -c",


### PR DESCRIPTION
As #63 and other changes have made the transpiled code into ES Modules, it's idiomatic to declare a `module` package, which is preferred by Rollup and other ESM-first bundlers.

See, for example, https://2ality.com/2019/10/hybrid-npm-packages.html