### PR TITLE
Added twemojiOptions to EmojiButton(options)

### DIFF
--- a/src/emoji.ts
+++ b/src/emoji.ts
@@ -44,7 +44,7 @@ export class Emoji {
         ? smile
         : `<img class="${CLASS_CUSTOM_EMOJI}" src="${this.emoji.emoji}">`;
     } else if (this.options.style === 'twemoji') {
-      content = this.lazy ? smile : twemoji.parse(this.emoji.emoji);
+      content = this.lazy ? smile : twemoji.parse(this.emoji.emoji, this.options.twemojiOptions);
     }
 
     this.emojiButton.innerHTML = content;

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,11 +41,6 @@ import {
 } from './types';
 import { EmojiArea } from './emojiArea';
 
-const twemojiOptions = {
-  ext: '.svg',
-  folder: 'svg'
-};
-
 const DEFAULT_OPTIONS: EmojiButtonOptions = {
   position: 'auto',
   autoHide: true,
@@ -71,6 +66,10 @@ const DEFAULT_OPTIONS: EmojiButtonOptions = {
     'flags'
   ],
   style: 'native',
+  twemojiOptions: {
+    ext: '.svg',
+    folder: 'svg'
+  },
   emojisPerRow: 8,
   rows: 6,
   emojiSize: '1.8em',
@@ -252,7 +251,7 @@ export class EmojiButton {
             });
           } else if (this.options.style === 'twemoji') {
             twemoji.parse(emoji.emoji, {
-              ...twemojiOptions,
+              ...this.options.twemojiOptions,
               callback: (icon, options) => {
                 this.publicEvents.emit(EMOJI, {
                   url: `${options.base}${options.size}/${icon}${options.ext}`,
@@ -335,7 +334,7 @@ export class EmojiButton {
           } else if (this.options.style === 'twemoji') {
             element.innerHTML = twemoji.parse(
               element.dataset.emoji,
-              twemojiOptions
+              this.options.twemojiOptions
             );
             element.dataset.loaded = true;
             element.style.opacity = '1';

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -13,11 +13,6 @@ import {
   CLASS_CUSTOM_EMOJI
 } from './classes';
 
-const twemojiOptions = {
-  ext: '.svg',
-  folder: 'svg'
-};
-
 export class EmojiPreview {
   private emoji: HTMLElement;
   private name: HTMLElement;
@@ -47,7 +42,7 @@ export class EmojiPreview {
     if (emoji.custom) {
       content = `<img class="${CLASS_CUSTOM_EMOJI}" src="${emoji.emoji}">`;
     } else if (this.options.style === 'twemoji') {
-      content = twemoji.parse(emoji.emoji, twemojiOptions);
+      content = twemoji.parse(emoji.emoji, this.options.twemojiOptions);
     }
 
     this.emoji.innerHTML = content;

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,7 @@ export interface EmojiButtonOptions {
   theme?: EmojiTheme;
   categories?: Category[];
   style?: EmojiStyle;
+  twemojiOptions?: Object;
   emojisPerRow?: number;
   rows?: number;
   emojiSize?: string;


### PR DESCRIPTION
This PR adds the missing twemojiOptions to src/emoji.ts (see https://github.com/joeattardi/emoji-button/issues/111) and moves them to EmojiButton constructor's options argument. This way the user can use twemoji's options like 'base' to specify where to download the images.